### PR TITLE
Parsing -> Master, Made small changes to textures

### DIFF
--- a/include/cub3d.h
+++ b/include/cub3d.h
@@ -28,6 +28,10 @@ typedef struct s_mlx_img
 	int		width;
 	int		height;
 	void	*img;
+	char	*addr;
+	int		bits_per_pixel;
+	int		line_length;
+	int		endian;
 }	t_mlx_img;
 
 /* struct s_map

--- a/include/cub3d.h
+++ b/include/cub3d.h
@@ -16,6 +16,14 @@
 # include <libft.h>
 # include <mlx.h>
 
+enum
+{
+	SOUTH = 0,
+	WEST = 1,
+	NORTH = 2,
+	EAST = 3
+};
+
 // STRUCTURES
 /* struct s_mlx_img
  * All information required to work with an mlx image
@@ -69,10 +77,7 @@ typedef struct s_texture_info
 	int			is_initialized;
 	int			ceiling_color;
 	int			floor_color;
-	t_mlx_img	tex_n;
-	t_mlx_img	tex_s;
-	t_mlx_img	tex_w;
-	t_mlx_img	tex_e;
+	t_mlx_img	textures[4];
 }	t_tex_info;
 
 // FUNCTIONS

--- a/src/convert_tex.c
+++ b/src/convert_tex.c
@@ -74,5 +74,7 @@ int	convert_tex(char **s, t_tex_info *ti)
 		ft_putstr_fd("Error: Could not open image\n", 2);
 		return (0);
 	}
+	mlx_get_data_addr(img->img, &img->bits_per_pixel,
+		&img->line_length, &img->endian);
 	return (1);
 }

--- a/src/convert_tex.c
+++ b/src/convert_tex.c
@@ -74,7 +74,7 @@ int	convert_tex(char **s, t_tex_info *ti)
 		ft_putstr_fd("Error: Could not open image\n", 2);
 		return (0);
 	}
-	mlx_get_data_addr(img->img, &img->bits_per_pixel,
+	img->addr = mlx_get_data_addr(img->img, &img->bits_per_pixel,
 		&img->line_length, &img->endian);
 	return (1);
 }

--- a/src/convert_tex.c
+++ b/src/convert_tex.c
@@ -26,22 +26,22 @@ static t_mlx_img	*get_img_p(char *s, t_tex_info *ti)
 	if (!ft_strncmp(s, "NO", 3))
 	{
 		ti->is_initialized |= 1 << 5;
-		return (&ti->tex_n);
+		return (&ti->textures[NORTH]);
 	}
 	else if (!ft_strncmp(s, "SO", 3))
 	{
 		ti->is_initialized |= 1 << 4;
-		return (&ti->tex_s);
+		return (&ti->textures[SOUTH]);
 	}
 	else if (!ft_strncmp(s, "WE", 3))
 	{
 		ti->is_initialized |= 1 << 3;
-		return (&ti->tex_w);
+		return (&ti->textures[WEST]);
 	}
 	else if (!ft_strncmp(s, "EA", 3))
 	{
 		ti->is_initialized |= 1 << 2;
-		return (&ti->tex_e);
+		return (&ti->textures[EAST]);
 	}
 	return (0);
 }

--- a/src/tex_info.c
+++ b/src/tex_info.c
@@ -37,28 +37,24 @@ void	init_tex_info(t_tex_info *t)
 	t->is_initialized = 0;
 	t->ceiling_color = 0;
 	t->floor_color = 0;
-	t->tex_n.img = 0;
-	t->tex_s.img = 0;
-	t->tex_e.img = 0;
-	t->tex_w.img = 0;
+	t->textures[NORTH].img = 0;
+	t->textures[SOUTH].img = 0;
+	t->textures[EAST].img = 0;
+	t->textures[WEST].img = 0;
 }
 
 // Will clean up memory for t_tex_info
 void	destroy_tex_info(t_tex_info *t)
 {
-	if ((t->is_initialized >> 5) & 1 && t->tex_n.img)
-		mlx_destroy_image(*get_mlx_ptr(), t->tex_n.img);
-	if ((t->is_initialized >> 4) & 1 && t->tex_s.img)
-		mlx_destroy_image(*get_mlx_ptr(), t->tex_s.img);
-	if ((t->is_initialized >> 3) & 1 && t->tex_w.img)
-		mlx_destroy_image(*get_mlx_ptr(), t->tex_w.img);
-	if ((t->is_initialized >> 2) & 1 && t->tex_e.img)
-		mlx_destroy_image(*get_mlx_ptr(), t->tex_e.img);
-	t->tex_n.img = 0;
-	t->tex_s.img = 0;
-	t->tex_e.img = 0;
-	t->tex_w.img = 0;
-	t->is_initialized = 0;
+	if ((t->is_initialized >> 5) & 1 && t->textures[NORTH].img)
+		mlx_destroy_image(*get_mlx_ptr(), t->textures[NORTH].img);
+	if ((t->is_initialized >> 4) & 1 && t->textures[SOUTH].img)
+		mlx_destroy_image(*get_mlx_ptr(), t->textures[SOUTH].img);
+	if ((t->is_initialized >> 3) & 1 && t->textures[WEST].img)
+		mlx_destroy_image(*get_mlx_ptr(), t->textures[WEST].img);
+	if ((t->is_initialized >> 2) & 1 && t->textures[EAST].img)
+		mlx_destroy_image(*get_mlx_ptr(), t->textures[EAST].img);
+	init_tex_info(t);
 }
 
 /* set_texture_info


### PR DESCRIPTION
Textures now initialize with more data.
When destroying the textures the img pointers are no longer set to **NULL**. You can check if they are initialized by using the `is_initialized` variable.
`tex_info` now uses an array to store textures instead of separate variables
